### PR TITLE
[mod] k8s event watch 기능이 HA 고려하도록 수정 및 main.go init 과정 리팩토링

### DIFF
--- a/main.go
+++ b/main.go
@@ -660,13 +660,13 @@ func serveWebsocket(res http.ResponseWriter, req *http.Request) {
 }
 
 func serveBindableResources(res http.ResponseWriter, req *http.Request) {
-	klog.Infof("Http request: method=%s, uri=%s", req.Method, req.URL.Path)
+	klog.V(3).Infof("Http request: method=%s, uri=%s", req.Method, req.URL.Path)
 
 	switch req.Method {
 	case http.MethodGet:
 		util.SetResponse(res, "", caller.GetBindableResources(), http.StatusOK)
 	default:
-		klog.Errorf("method not acceptable")
+		klog.V(1).Infof("method not acceptable")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -691,8 +691,10 @@ func runLeaderElection(lock *resourcelock.LeaseLock, ctx context.Context, id str
 			OnStartedLeading: func(c context.Context) {
 				// metering
 				cronJob_Metering.Start()
+				klog.V(3).Info("Start metering service")
 				// k8s event logging
 				caller.WatchK8sEvent()
+				klog.V(3).Info("Start event service")
 			},
 			OnStoppedLeading: func() {
 				klog.V(3).Info("no longer the leader, staying inactive and stop metering & event logging")

--- a/util/caller/K8sApiCaller.go
+++ b/util/caller/K8sApiCaller.go
@@ -39,6 +39,7 @@ var Clientset *kubernetes.Clientset
 var config *restclient.Config
 var customClientset *client.Clientset
 var AuditResourceList []string
+var EventWatchChannel chan struct{}
 
 func init() {
 	// var kubeconfig *string
@@ -81,6 +82,7 @@ func init() {
 		panic(err.Error())
 	}
 
+	EventWatchChannel = make(chan struct{})
 }
 
 func GetBindableResources() map[string]string {
@@ -1279,8 +1281,8 @@ func WatchK8sEvent() {
 		},
 	)
 
-	stop := make(chan struct{})
-	go controller.Run(stop)
+	EventWatchChannel = make(chan struct{})
+	go controller.Run(EventWatchChannel)
 }
 
 func UpdateAuditResourceList() {

--- a/util/caller/K8sApiCaller.go
+++ b/util/caller/K8sApiCaller.go
@@ -97,16 +97,16 @@ func GetBindableResources() map[string]string {
 
 	data, err := Clientset.RESTClient().Get().AbsPath("/apis/tmax.io/v1/clustertemplates/").DoRaw(context.TODO())
 	if err != nil {
-		klog.Error(err)
+		klog.V(1).Infoln(err)
 	} else {
 		if err := json.Unmarshal(data, &clusterTemplates); err != nil {
-			klog.Errorln(err)
+			klog.V(1).Infoln(err)
 		} else {
 			for _, templateItem := range clusterTemplates.Items {
 				for _, objectKind := range templateItem.TemplateSpec.Objects {
 					err := json.Unmarshal(objectKind.Raw, &temObj)
 					if err != nil {
-						klog.Error(err)
+						klog.V(1).Infoln(err)
 					} else {
 						objectList[temObj.Kind] = temObj.ApiVersion
 					}


### PR DESCRIPTION
event watch 서비스를 leader election 로직 안에 포함시켜서 HA를 고려하도록 수정

추가적으로 main.go의 init() 과정 중, init_metering이 init_logging 내부에 포함되도록 수정하였고,
init_metering 안에 포함되어있던 leader election을 밖으로 빼내어 metering 서비스에 종속되는 것처럼 보이지 않도록 수정

