### PR TITLE
[etc] version.config를 최초 기동 시 한 번만 read 하도록 리팩토링

### DIFF
--- a/version/versionHandler.go
+++ b/version/versionHandler.go
@@ -22,11 +22,13 @@ import (
 	"k8s.io/klog"
 )
 
-// Get handles ~/version get method
-func Get(res http.ResponseWriter, req *http.Request) {
-	klog.V(3).Infoln("**** GET /version")
-	var conf versionModel.Config
+var (
+	result     []versionModel.Module
+	conf       versionModel.Config
+	configSize int
+)
 
+func init() {
 	// 1. READ CONFIG FILE
 	// File path should be same with what declared on volume mount in yaml file.
 	yamlFile, err := ioutil.ReadFile("/go/src/version/version.config")
@@ -38,10 +40,13 @@ func Get(res http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		klog.V(1).Infoln(err)
 	}
-	configSize := len(conf.Modules)
-	result := make([]versionModel.Module, configSize)
+	configSize = len(conf.Modules)
+	result = make([]versionModel.Module, configSize)
+}
 
-	// Main algorithm
+// Get handles ~/version get method
+func Get(res http.ResponseWriter, req *http.Request) {
+	klog.V(3).Infoln("**** GET /version")
 	var wg sync.WaitGroup
 	wg.Add(configSize)
 


### PR DESCRIPTION
version.config를 최초 기동 시 한 번만 리팩토링하여 file read 오버헤드를 줄임

근거
* file read 오버헤드가 줄어듦
* version.config는 업데이트 될 일이 거의 없으므로 매번 읽을 필요성이 부족함
* version.config가 업데이트 되더라도, subPath로 마운트되었기 때문에 어차피 version.config의 변경사항은 컨테이너에 런타임으로 반영이 되지 않기 때문에, 반드시 pod를 재기동해야함