### PR TITLE
[feat] 콘솔에서 kubectl CLI 기능 제공을 위한 백엔드 기능 추가

### DIFF
--- a/util/constants.go
+++ b/util/constants.go
@@ -29,10 +29,14 @@ const (
 	QUERY_PARAMETER_HOST           = "host"
 
 	//HyperAuth
-	//HYPERAUTH_URL = "http://hyperauth.hyperauth"
-	HYPERAUTH_URL                                    = "http://192.168.6.151"
-	HYPERAUTH_SERVICE_NAME_LOGIN_AS_ADMIN            = "auth/realms/master/protocol/openid-connect/token"
-	HYPERAUTH_SERVICE_NAME_USER_DETAIL_WITHOUT_TOKEN = "auth/realms/tmax/user/"
+	HYPERAUTH_SERVICE_NAME_LOGIN_AS_ADMIN = "/auth/realms/master/protocol/openid-connect/token"
+	HYPERAUTH_SERVICE_NAME_USER_DETAIL    = "/auth/realms/tmax/user/"
+
+	HYPERCLOUD_KUBECTL_NAMESPACE   = "hypercloud-kubectl"
+	HYPERCLOUD_KUBECTL_PREFIX      = "hypercloud-kubectl-"
+	HYPERCLOUD_KUBECTL_IMAGE       = "bitnami/kubectl:1.25.3"
+	HYPERCLOUD_KUBECTL_LABEL_KEY   = "hypercloud"
+	HYPERCLOUD_KUBECTL_LABEL_VALUE = "kubectl"
 
 	HYPERCLOUD4_NAMESPACE       = "hypercloud4-system"
 	HYPERCLOUD4_CLAIM_API_GROUP = "claim.tmax.io"

--- a/util/consumer/kafkaConsumer.go
+++ b/util/consumer/kafkaConsumer.go
@@ -219,6 +219,9 @@ func (consumer *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, clai
 			// Delete RoleBinding
 			k8sApiCaller.DeleteRBWithUser(topicEvent.UserName)
 
+			// Delete kubectl pod related resources
+			k8sApiCaller.DeleteKubectlResourceByUserName(topicEvent.UserName)
+
 			// 사용자에 대해서..
 			// cluster의 주인인 경우.. 클러스터와 관련된 모든걸 지운다.
 			// 1. master에서 clm 지우면 됨 (+db)

--- a/version/versionHandler.go
+++ b/version/versionHandler.go
@@ -42,6 +42,15 @@ func init() {
 	}
 	configSize = len(conf.Modules)
 	result = make([]versionModel.Module, configSize)
+
+	for _, mod := range conf.Modules {
+		if mod.Name == "HyperAuth" {
+			idx := strings.Index(mod.ReadinessProbe.HTTPGet.Path, "/auth/realms")
+			k8sApiCaller.HYPERAUTH_URL = mod.ReadinessProbe.HTTPGet.Path[:idx]
+			k8sApiCaller.HYPERAUTH_REALM_PREFIX = mod.ReadinessProbe.HTTPGet.Path[idx:]
+			break
+		}
+	}
 }
 
 // Get handles ~/version get method


### PR DESCRIPTION
[IMS 291634](https://ims.tmaxsoft.com/tody/ims/issue/issueView.do?issueId=291634&menuCode=issue_search) 참고

추가 기능 특징
* POST ~/kubectl?userName={유저아이디} 콜을 보내면, kubectl pod 및 관련 리소스 생성
* KUBECTL_TIMEOUT 환경변수를 통해 pod 유지시간을 조절 할 수 있음 (default 6시간)
* 생성된 리소스는 DELETE ~/kubectl?userName={유저아이디} 콜을 통해 삭제 가능, 혹은 hyperauth에서 유저 삭제 시 자동 삭제
* 매일 자정마다 잔존 리소스를 삭제하는 기능도 추가
* kubectl 이미지는 bitnami/kubectl:1.25.3 사용 중, hypercloud 이미지 리스트에 추가해야 함