### PR TITLE
kubectl 오류 수정 및 고도화

### DIFF
--- a/util/caller/K8sApiCaller.go
+++ b/util/caller/K8sApiCaller.go
@@ -1415,6 +1415,7 @@ func kubectlInit(userName string) error {
 					},
 					Resources: []string{
 						"pods/exec",
+						"pods",
 					},
 					ResourceNames: []string{
 						util.HYPERCLOUD_KUBECTL_PREFIX + ParseUserName(userName),


### PR DESCRIPTION
* 생성되는 kubectl pod에 대한 GET 권한 추가
* kubectl 리소스 GC 기능을 leader election 안으로 옮겨서, HA 환경에서 pod 하나만 수행하도록 수정