### PR TITLE
kubectl 기능 오류 해결

### DIFF
--- a/kubectl/kubectlHandler.go
+++ b/kubectl/kubectlHandler.go
@@ -81,6 +81,7 @@ func Post(res http.ResponseWriter, req *http.Request) {
 	klog.V(3).Infoln("userName =", userName)
 	if err := caller.DeployKubectlPod(userName); err != nil {
 		util.SetResponse(res, "", err, http.StatusBadRequest)
+		caller.DeleteKubectlResourceByUserName(userName)
 	} else {
 		util.SetResponse(res, "Create Kubectl Pod Success", nil, http.StatusOK)
 	}


### PR DESCRIPTION
* kubectl 리소스 생성 도중 실패 시, 만들었던 리소스 삭제하는 로직 추가 [300246]
* k8s 1.24 버전 이상에서의 호환을 위해 ServiceAccount를 위한 Secret 수동 생성 [300330]
